### PR TITLE
UPDATE left sidebar fixed, independent on scrolling main content

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -23,6 +23,9 @@ body {
   width: 300px;
   background-color: var(--bg-grey-xlight);
   box-shadow: 2px -2px 2px 0 rgb(0 0 0 / 14%);
+  position:fixed;
+  height:95%;
+  overflow:auto;
 }
 .side-nav li { border-bottom: 1px solid var(--nav-border); }
 .side-nav li.heading { box-shadow: var(--sd-basic); }
@@ -39,7 +42,7 @@ body > header { display: flex; align-items: center; height: 3rem; padding: 0 0.7
   body > header a:not(:first-of-type) { display: flex; align-items: center; height: 2.5rem; margin-left: 0.5rem; padding: 0 0.5rem; border: 2px solid var(--bg-pink); border-radius: 0.25rem; }
   body > header a:not(:first-of-type):hover { border-color: var(--bg-purple); }
 
-main { max-width: 1536px; padding: 0 8px; margin: auto; }
+main { max-width: 1536px; padding: 0 8px; margin: auto; margin-left:300px;}
   main section { padding: 0.75rem; background-color: var(--bg-grey-xlight); border-radius: 1rem; }
   main section.section-heading { border-radius: 0.25rem; background: var(--bg-au-gradient); color: var(--bg-white); text-shadow: 0px 0px 4px rgb(0 0 0 / 70%); box-shadow: var(--sd-basic); }
   main section:not(.section-heading):target { box-shadow: 0 0 0.5rem 0.125rem var(--bg-purple); }

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -24,7 +24,7 @@ body {
   background-color: var(--bg-grey-xlight);
   box-shadow: 2px -2px 2px 0 rgb(0 0 0 / 14%);
   position:fixed;
-  height:95%;
+  height:calc(100% - 3em);
   overflow:auto;
 }
 .side-nav li { border-bottom: 1px solid var(--nav-border); }


### PR DESCRIPTION
This PR makes left sidebar fixed, thus scrolling is independent on main content. I can go to next examples and do not need to scroll up and down. 

Notes: 1) may-be the top bar should be made fixed too, 2) the height: 95% is because the top bar height shrinks the view. do not show the last item on all (weird) screensizes

![UTOnvFZjZd](https://user-images.githubusercontent.com/1429487/121330044-01b47800-c916-11eb-8af0-4d90585e4d54.gif)